### PR TITLE
Change owner of GOPATH to vagrant

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -64,6 +64,6 @@ apt-get install -y git bash-completion make build-essential libssl-dev \
 gem install bundler
 
 # XXX: I use this as my GOPATH. Is there a better default to use?
-su -c "mkdir ~/go" vagrant
+su -c "mkdir -p ~/go" vagrant
 ln -sf /usr/lib/go-1.9/bin/gofmt /usr/bin/
 ln -sf /usr/lib/go-1.9/bin/go /usr/bin/

--- a/provision.sh
+++ b/provision.sh
@@ -63,7 +63,5 @@ apt-get install -y git bash-completion make build-essential libssl-dev \
 
 gem install bundler
 
-# XXX: I use this as my GOPATH. Is there a better default to use?
-su -c "mkdir -p ~/go" vagrant
 ln -sf /usr/lib/go-1.9/bin/gofmt /usr/bin/
 ln -sf /usr/lib/go-1.9/bin/go /usr/bin/

--- a/provision.sh
+++ b/provision.sh
@@ -64,6 +64,6 @@ apt-get install -y git bash-completion make build-essential libssl-dev \
 gem install bundler
 
 # XXX: I use this as my GOPATH. Is there a better default to use?
-mkdir -p ~/go
+su -c "mkdir ~/go" vagrant
 ln -sf /usr/lib/go-1.9/bin/gofmt /usr/bin/
 ln -sf /usr/lib/go-1.9/bin/go /usr/bin/

--- a/user_provision.sh
+++ b/user_provision.sh
@@ -4,6 +4,11 @@
 # virtualenv-init depends on using unset variables, so you cannot use -u
 set -ex
 
+# Create GOPATH and add ~/go/bin to the $PATH for ease of using `go get ...`
+mkdir -p ~/go
+echo 'export GOPATH="/home/vagrant/go"' >> ~/.bash_profile
+echo 'export PATH="$PATH:$GOPATH/bin"' >> ~/.bash_profile
+
 # Use pyenv to install python 3.6.4. The apt-based solutions I tried really stunk.
 curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 echo 'export PATH="/home/vagrant/.pyenv/bin:$PATH"' >> ~/.bash_profile


### PR DESCRIPTION
Currently, the directory created for the `GOPATH` is owned by root. This causes permission errors if you try to `go get` something.

I haven't really tested this, but I think this will create the directory with vagrant as the owner.