### PR TITLE
Upgrade to ubuntu 18.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,13 @@ You don't need to to do this just to use it! See above.
   * elixir 1.7.3
   * erlang 21.0.5
   * golang 1.12.1
-  * java 12
+  * java 11.0.2 (openjdk)
+  * java 12.0.2 (openjdk)
+  * java 13.0.1 (openjdk)
   * node 12.7.0
   * php 7.3
   * python 2.7.16
-  * python 3.7.4
+  * python 3.8.2
   * ruby 2.6.3
   * rust 1.33.0
 
@@ -53,9 +55,11 @@ You don't need to to do this just to use it! See above.
   * ansible
   * bundler
   * cargo
+  * jenv
   * leiningen
   * maven
   * nginx
+  * pipenv
   * pyenv
   * runit
   * rustup

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,4 +3,8 @@
 
 Vagrant.configure("2") do |config|
   config.vm.box = "multidev.box"
+
+  # Uncomment this line if you need to re-run the user provisioning script
+  # without re-building the box.
+  # config.vm.provision "shell", path: "user_provision.sh", privileged: false
 end

--- a/envimation/Makefile
+++ b/envimation/Makefile
@@ -1,4 +1,4 @@
 .PHONY: download
 download:
-	wget https://app.vagrantup.com/envimation/boxes/ubuntu-xenial/versions/1.0.3-1505697275/providers/virtualbox.box
+	wget https://vagrantcloud.com/hashicorp/boxes/bionic64/versions/1.0.282/providers/virtualbox.box
 	tar -xzvf virtualbox.box 

--- a/provision.sh
+++ b/provision.sh
@@ -60,4 +60,8 @@ apt-get install -y --no-install-recommends yarn
 # download and install go 1.11 to /usr/local/go
 curl -sS https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 
+# install leiningen for clojure
+curl -sSL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein
+chmod a+x /usr/bin/lein
+
 sudo apt-get -y install ponyc

--- a/provision.sh
+++ b/provision.sh
@@ -46,7 +46,6 @@ apt-get install -y git bash-completion make build-essential libssl-dev \
   esl-erlang \
   nginx \
   ponyc \
-  python3.8 \
   runit
 
 # Need to install php with --no-recommends to prevent apache2 from being installed

--- a/provision.sh
+++ b/provision.sh
@@ -45,10 +45,13 @@ apt-get install -y git bash-completion make build-essential libssl-dev \
   elixir \
   esl-erlang \
   nginx \
-  oracle-java12-installer oracle-java12-set-default maven \
-  php7.3 php7.3-mbstring \
   ponyc \
-  runit \
+  python3.8 \
+  runit
+
+# Need to install php with --no-recommends to prevent apache2 from being installed
+apt-get install --no-install-recommends -y php7.3 php7.3-mbstring
+
 
 # yarn is a special snowflake; we want to install it independent of debian's
 # node, so we have to do this. cf: https://yarnpkg.com/en/docs/install#debian-stable
@@ -56,10 +59,5 @@ apt-get install -y --no-install-recommends yarn
 
 # download and install go 1.11 to /usr/local/go
 curl -sS https://dl.google.com/go/go1.12.1.linux-amd64.tar.gz | tar -C /usr/local -xz
-
-# install leiningen for clojure
-curl -sSL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein && \
-    chmod a+x /usr/bin/lein && \
-    /usr/bin/lein
 
 sudo apt-get -y install ponyc

--- a/user_provision.sh
+++ b/user_provision.sh
@@ -1,15 +1,16 @@
 # Everything in this file is run as the vagrant user, while the `provision.sh` script
-# is run as superuser
+# is run as superuser. In the normal build process this is run by packer. It
+# can also be run via the Vagrantfile with `vagrant provision`
 
 # virtualenv-init depends on using unset variables, so you cannot use -u
 set -ex
 
 # Install jenv for switching between versions.
-if [[ ! -e "$HOME/.jenv" ]]; then
-    git clone https://github.com/jenv/jenv.git ~/.jenv
-    mkdir "$HOME/.jenv/versions"
-    echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
-fi
+test -d ~/.jenv && rm -rf ~/.jenv
+git clone https://github.com/jenv/jenv.git ~/.jenv
+mkdir ~/.jenv/versions
+echo 'export PATH="~/.jenv/bin:$PATH"' >> ~/.bash_profile
+echo 'eval "$(jenv init -)"' >> ~/.bash_profile
 
 function download_java {
     url="$1"
@@ -24,23 +25,13 @@ download_java "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c
 download_java "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz"
 download_java "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz"
 
-find . -wholename "**/bin/java" | \
-    while read -r java_bin; do
-        jdk_dir="${java_bin%*/bin/java}"
-        "$HOME/.jenv/bin/jenv" add "$jdk_dir"
-    done
-
-# install leiningen for clojure
-# curl -sSL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein && \
-#     chmod a+x /usr/bin/lein && \
-#     /usr/bin/lein
-
 # Create GOPATH and add GO root and ~/go/bin to the $PATH for ease of using `go get ...`
 mkdir -p ~/go
 echo 'export GOPATH="$HOME/go"' >> ~/.bash_profile
 echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> ~/.bash_profile
 
 # Use pyenv to install python 3.6.4. The apt-based solutions I tried really stunk.
+test -d ~/.pyenv && rm -rf ~/.pyenv
 curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
 echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
@@ -50,6 +41,7 @@ echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bash_profile
 # nodenv-installer requires you to put these on the path before it runs:
 # https://github.com/nodenv/nodenv-installer/issues/8
 export PATH="$HOME/.nodenv/bin:$HOME/.nodenv/shims:$PATH"
+test -d ~/.nodenv && rm -rf ~/.nodenv
 curl -fsSL https://github.com/nodenv/nodenv-installer/raw/master/bin/nodenv-installer | bash
 echo 'export PATH="$HOME/.nodenv/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(nodenv init -)"' >> ~/.bash_profile
@@ -59,6 +51,7 @@ echo 'eval "$(nodenv init -)"' >> ~/.bash_profile
 # rbenv-installer requires you to put these on the path before it runs
 # apparently too
 export PATH="$HOME/.rbenv/bin:$HOME/.rbenv/shims:$PATH"
+test -d ~/.rbenv && rm -rf ~/.rbenv
 curl -fsSL https://github.com/rbenv/rbenv-installer/raw/master/bin/rbenv-installer | bash
 echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
@@ -66,6 +59,16 @@ echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 # Once done installing the *envs, fix up the bash_profile and source it
 echo 'source ~/.bashrc' >> ~/.bash_profile
 source ~/.bash_profile
+
+find . -wholename "**/bin/java" | \
+    while read -r java_bin; do
+        jdk_dir="${java_bin%*/bin/java}"
+        jenv add "$jdk_dir"
+    done
+jenv global 13
+
+# Now that java is installed, run lein to ensure it works.
+lein
 
 # then finally install some versions
 pyenv install 3.8.2

--- a/user_provision.sh
+++ b/user_provision.sh
@@ -33,7 +33,7 @@ echo 'export PATH="$PATH:/usr/local/go/bin:$GOPATH/bin"' >> ~/.bash_profile
 # Use pyenv to install python 3.6.4. The apt-based solutions I tried really stunk.
 test -d ~/.pyenv && rm -rf ~/.pyenv
 curl -L https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer | bash
-echo 'export PATH="$HOME/.pyenv/bin:$PATH"' >> ~/.bash_profile
+echo 'export PATH="$HOME/.pyenv/bin:$HOME/.local/bin:$PATH"' >> ~/.bash_profile
 echo 'eval "$(pyenv init -)"' >> ~/.bash_profile
 echo 'eval "$(pyenv virtualenv-init -)"' >> ~/.bash_profile
 

--- a/user_provision.sh
+++ b/user_provision.sh
@@ -4,6 +4,37 @@
 # virtualenv-init depends on using unset variables, so you cannot use -u
 set -ex
 
+# Install jenv for switching between versions.
+if [[ ! -e "$HOME/.jenv" ]]; then
+    git clone https://github.com/jenv/jenv.git ~/.jenv
+    mkdir "$HOME/.jenv/versions"
+    echo 'export PATH="$HOME/.jenv/bin:$PATH"' >> ~/.bash_profile
+fi
+
+function download_java {
+    url="$1"
+    filename=$(basename "$url")
+    if [[ ! -e "$filename" ]]; then
+        curl -O "$url"
+        tar -xzf "$filename"
+    fi
+}
+
+download_java "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz"
+download_java "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz"
+download_java "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz"
+
+find . -wholename "**/bin/java" | \
+    while read -r java_bin; do
+        jdk_dir="${java_bin%*/bin/java}"
+        "$HOME/.jenv/bin/jenv" add "$jdk_dir"
+    done
+
+# install leiningen for clojure
+# curl -sSL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein && \
+#     chmod a+x /usr/bin/lein && \
+#     /usr/bin/lein
+
 # Create GOPATH and add GO root and ~/go/bin to the $PATH for ease of using `go get ...`
 mkdir -p ~/go
 echo 'export GOPATH="$HOME/go"' >> ~/.bash_profile
@@ -37,12 +68,13 @@ echo 'source ~/.bashrc' >> ~/.bash_profile
 source ~/.bash_profile
 
 # then finally install some versions
-pyenv install 3.7.4
+pyenv install 3.8.2
 pyenv install 2.7.16
 nodenv install 12.7.0
 rbenv install 2.6.3
 
-pyenv global 3.7.4
+pyenv global 3.8.2
+pip3 install --user pipenv
 nodenv global 12.7.0
 rbenv global 2.6.3
 


### PR DESCRIPTION
This upgrades multidevbox to ubuntu 18. It swaps out the ubuntu java packages in favor of the binary openjdk releases because they should be less of a maintenance burden. I've left this as a draft PR for now because I haven't been able to make `lein` work yet.