### PR TITLE
re-add Maven

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ clean:
 	-vagrant box remove -f multidev.box
 
 .PHONY: publish 
-publish: multidev.box
-	# now upload the box to vagrant cloud
+publish:
+	# upload the box to vagrant cloud
 	vagrant cloud box show llimllib/multidev
 	read -p "New version number: " version; \
 	vagrant cloud publish --force --release llimllib/multidev $$version virtualbox multidev.box

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,16 @@
-.PHONY: package
-package: multidev.box
+multidev.box: provision.sh user_provision.sh packer.json clean
+	packer build packer.json
+
+.PHONY: clean
+clean:
+	# clear out the box so vagrant up uses the new one instead of its cached
+	# copy
+	-vagrant box remove -f multidev.box
+
+.PHONY: publish 
+publish: multidev.box
 	# now upload the box to vagrant cloud
 	vagrant cloud box show llimllib/multidev
 	read -p "New version number: " version; \
 	vagrant cloud publish --force --release llimllib/multidev $$version virtualbox multidev.box
 	@# ( https://stackoverflow.com/a/12170504/42559 for the one-line @read trick)
-
-multidev.box: provision.sh user_provision.sh packer.json
-	packer build packer.json
-	# clear out the box so vagrant up uses thte new one instead of its cached copy
-	vagrant box remove multidev.box

--- a/user_provision.sh
+++ b/user_provision.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Everything in this file is run as the vagrant user, while the `provision.sh` script
 # is run as superuser. In the normal build process this is run by packer. It
 # can also be run via the Vagrantfile with `vagrant provision`
@@ -18,12 +19,20 @@ function download_java {
     if [[ ! -e "$filename" ]]; then
         curl -OsSf "$url"
         tar -xzf "$filename"
+        rm "$filename"
     fi
 }
 
 download_java "https://download.java.net/java/GA/jdk13.0.1/cec27d702aa74d5a8630c65ae61e4305/9/GPL/openjdk-13.0.1_linux-x64_bin.tar.gz"
 download_java "https://download.java.net/java/GA/jdk12.0.2/e482c34c86bd4bf8b56c0b35558996b9/10/GPL/openjdk-12.0.2_linux-x64_bin.tar.gz"
 download_java "https://download.java.net/java/GA/jdk11/9/GPL/openjdk-11.0.2_linux-x64_bin.tar.gz"
+
+# install maven into ~/maven/
+# https://maven.apache.org/install.html
+mkdir ~/maven/
+curl "https://apache.cs.utah.edu/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz" | \
+    tar xz --strip-components=1 -C ~/maven
+echo 'export PATH="~/maven/bin:$PATH"' >> ~/.bash_profile
 
 # Create GOPATH and add GO root and ~/go/bin to the $PATH for ease of using `go get ...`
 mkdir -p ~/go
@@ -64,6 +73,10 @@ curl --proto '=https' --tlsv1.2 -qsSf https://raw.githubusercontent.com/ponylang
 echo 'source ~/.bashrc' >> ~/.bash_profile
 source ~/.bash_profile
 
+# enable the export of JAVA_HOME
+jenv enable-plugin export
+
+# tell jenv what java versions we've added
 find . -wholename "**/bin/java" | \
     while read -r java_bin; do
         jdk_dir="${java_bin%*/bin/java}"


### PR DESCRIPTION
In 08473a09ab2211fddcd77ad3ca3ec5fb5366e9a4, maven got accidentally removed
when we reworked the java install procedure. Re-add maven.

Also:

* remove java tarballs from the homedir
* export `JAVA_HOME` from jenv
* update the makefile not to publish the box by default