### PR TITLE
Install docker for noclist server

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -68,3 +68,6 @@ curl -sSf https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -C /usr/local
 # install leiningen for clojure
 curl -sSfL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein
 chmod a+x /usr/bin/lein
+
+# install docker for noclist server
+snap install docker

--- a/provision.sh
+++ b/provision.sh
@@ -69,5 +69,5 @@ curl -sSf https://dl.google.com/go/go1.14.linux-amd64.tar.gz | tar -C /usr/local
 curl -sSfL https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein -o /usr/bin/lein
 chmod a+x /usr/bin/lein
 
-# install docker for noclist server
+# install docker
 snap install docker


### PR DESCRIPTION
It may be convenient to have docker installed in the environment.
Using snap as it installs an up-to-date version, simply.