### PR TITLE
Update README and Vagrantfile for correctness

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@ environments.
 ## How to use it
 
 * install [Vagrant](https://www.vagrantup.com/)
-* Create a file called `Vagrantfile` with these contents:
-
-```
-Vagrant.configure("2") do |config|
-  # https://github.com/llimllib/multidevbox
-  config.vm.box = "llimllib/multidev"
-end
-```
-
 * run `vagrant up`
 * run `vagrant ssh` to ssh into your newly created box. That's it!
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "multidev.box"
+  # https://github.com/llimllib/multidevbox
+  config.vm.box = "llimllib/multidev"
 
   # Uncomment either of these lines if you want to re-run the a provisioning
   # script without rebuilding the box, then run `vagrant up --provision`


### PR DESCRIPTION
The README says to create a Vagrantfile with a specific `config.vm.box` value, however the multidevbox repo already includes a Vagrantfile configured with a different value for `config.vm.box` that does not appear to work.

**Proposed Changes**
* Remove the obsolete instruction from the README
* Use the config value from the README in the existing Vagrantfile